### PR TITLE
Add data processing functions for grammar questionnaire

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -7,8 +7,6 @@ if (interactive()) {
   cli::cli_alert_info(R.version$version.string)
   cli::cli_text("")
 
-
-
   # usethis options
   options(usethis.protocol = "ssh")
   options(usethis.full_name = "gongcastro")
@@ -16,17 +14,4 @@ if (interactive()) {
   # bias against scientific notation
   options(scipen = 4)
 
-  # # print loaded packages
-  # cli::cli_alert_success(
-  #   paste0(
-  #     "Loaded: ",
-  #     paste0(
-  #       sessioninfo::session_info()$packages[sessioninfo::session_info()$packages$attached, 1],
-  #       collapse = ", "
-  #     )
-  #   )
-  # )
-  # cli::cli_text("")
-
-  # devtools::load_all()
 }

--- a/.Rprofile
+++ b/.Rprofile
@@ -7,14 +7,6 @@ if (interactive()) {
   cli::cli_alert_info(R.version$version.string)
   cli::cli_text("")
 
-  # customise the prompt
-  prompt::set_prompt(function(...) {
-    branch <- suppressWarnings(purrr::safely(gert::git_branch)())
-    if (is.null(branch$result)) {
-      return("> ")
-    }
-    return(paste0("[", branch$result, "] > "))
-  })
 
 
   # usethis options
@@ -24,17 +16,17 @@ if (interactive()) {
   # bias against scientific notation
   options(scipen = 4)
 
-  # print loaded packages
-  cli::cli_alert_success(
-    paste0(
-      "Loaded: ",
-      paste0(
-        sessioninfo::session_info()$packages[sessioninfo::session_info()$packages$attached, 1],
-        collapse = ", "
-      )
-    )
-  )
-  cli::cli_text("")
+  # # print loaded packages
+  # cli::cli_alert_success(
+  #   paste0(
+  #     "Loaded: ",
+  #     paste0(
+  #       sessioninfo::session_info()$packages[sessioninfo::session_info()$packages$attached, 1],
+  #       collapse = ", "
+  #     )
+  #   )
+  # )
+  # cli::cli_text("")
 
-  load_all()
+  # devtools::load_all()
 }

--- a/R/connect.R
+++ b/R/connect.R
@@ -42,7 +42,7 @@ bvq_connect <- function(google_email = NULL,
   # if key exists, use it to log in
   tryCatch(
     suppressWarnings(
-      formr::formr_connect(keyring = "formr")
+      formr::formr_connect(email = formr_email, keyring = "formr")
     ),
     error = function(e) {
       cli_abort(

--- a/R/connect.R
+++ b/R/connect.R
@@ -35,7 +35,7 @@ bvq_connect <- function(google_email = NULL,
   if (is.null(password)) {
     password <- Sys.getenv("FORMR_PWD", unset = NA)
     if (is.na(password)) {
-      cli_abort("Please, provide a password")
+      cli::cli_abort("Please, provide a password")
     }
   }
 
@@ -56,7 +56,7 @@ bvq_connect <- function(google_email = NULL,
   )
 
   # check if Google credentials exists, ask for them if not
-  if (!gs4_has_token()) {
+  if (!googlesheets4::gs4_has_token()) {
     tryCatch(
       suppressWarnings({
         googlesheets4::gs4_auth(

--- a/R/import.R
+++ b/R/import.R
@@ -2,7 +2,7 @@
 #'
 #' @importFrom cli cli_alert_success
 #' 
-#' @param version Character string indicating the name fo the formr run (must be one of "lockdown", "long", or "short")
+#' @param version Character string indicating the name fo the formr run (must be one of "bvq-1.0.1", "bvq-1.0.0", "bvq-lockdown", "bvq-long", or "bvq-short")
 #' @param participants Participants dataset, as returned by [bvq::bvq_participants()]
 #' @param ... Unused.
 #' 
@@ -19,7 +19,7 @@ collect_survey <- function(version,
     # validate version name
     survey_options <- names(get_bvq_runs())
     if (!(version %in% survey_options)) {
-        cli_abort("survey must be one of {survey_options}")
+        cli::cli_abort("survey must be one of {survey_options}")
     }
     
     # correct version names
@@ -47,7 +47,7 @@ collect_survey <- function(version,
     if (interactive()) {
         n_responses <- nrow(distinct(processed, response_id))
         msg <- "{version} updated: {n_responses} response{?s} retrieved"
-        cli_alert_success(msg)
+        cli::cli_alert_success(msg)
     }
     
     return(processed)
@@ -78,7 +78,7 @@ download_surveys <- function(surveys, verbose = TRUE, ...) {
     
     if (verbose && interactive()) {
         step_msg <- "Downloaded {i}/{n} {qty(i)}survey{?s}"
-        cli_progress_step(msg = step_msg)
+        cli::cli_progress_step(msg = step_msg)
     }
     
     for (i in seq_along(surveys)) {

--- a/R/participants.R
+++ b/R/participants.R
@@ -57,7 +57,7 @@ bvq_participants <- function(...) {
     sheet <- read_sheet(
       ss = "164DMKLRO0Xju0gdfkCS3evAq9ihTgEgFiuJopmqt7mo",
       sheet = "Participants",
-      col_types = "cccciDnccccDDclcc",
+      col_types = "cccciDnccccDDcllcc",
       .name_repair = janitor::make_clean_names
     )
   })
@@ -74,7 +74,7 @@ bvq_participants <- function(...) {
     ) %>%
     mutate(
       response_id = gsub("BL", "", response_id),
-      version = gsub("bl-", "", tolower(version))
+      version = gsub("bl-|bvq-", "", tolower(version))
     ) %>%
     # reorder rows
     arrange(desc(as.numeric(response_id)))

--- a/R/utils.R
+++ b/R/utils.R
@@ -304,7 +304,8 @@ get_bvq_runs <- function() { # nocov start
             "bvq_04_demo",
             "bvq_05_language",
             "bvq_06_words_catalan",
-            "bvq_06_words_spanish"
+            "bvq_06_words_spanish",
+            "bvq_grammar"
         ),
         "bvq-lockdown" = c(
             "bilexicon_lockdown_01_log",


### PR DESCRIPTION
-Fixes #60: the API has to support the new `bvq_grammar` questionnaire.

- [x] Change `bvq_participants()` so that it supports the new column `is_preterm` in Google Sheets.
- [x] Add `bvq_grammar` to questionnaire list in the `bvq_1.0.1` element in the `bvq_get_runs()` function.
- [ ] Add new function to process and display results from `bvq_grammar`.